### PR TITLE
Add a link to the msgspec EdgeDB integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Want to contribute to the list? Follow the [contributing guide](/CONTRIBUTING.md
 - [EdgeDB FastAPI Users](https://github.com/0xsirsaif/fastapiusers-edgedb) - An adapter for FastAPI Users that utilizes EdgeDB as storage.
 - [EdgeDB Grafana Backend](https://github.com/washed/edgedb-grafana-backend) - A Grafana backend plugin allowing you to use EdgeDB as a data source.
 - [EdgeDB Grafana Frontend](https://github.com/edgedb/edgedb-grafana-frontend) - A Grafana frontend plugin allowing you to fetch data from EdgeDB's HTTP endpoint.
+- [EdgeDB Msgspec Integration](https://jcristharif.com/msgspec/examples/edgedb.html) - Documentation on integrating EdgeDB with the msgspec JSON serialization & validation library.
 
 ## Templates
 - [Create T3-EdgeDB App](https://github.com/PastelStoic/create-t3-edgedb-app) - The [T3 stack](https://init.tips/), but the database of choice is EdgeDB.


### PR DESCRIPTION
The lastest [msgspec](https://github.com/jcrist/msgspec) release includes builtin support for most `edgedb-python` objects. I wrote up a docs page on recommended methods for integrating the libraries together. Not sure if this is the best location in this page, but figured I'd open a PR.