### PR TITLE
docs: :sparkles: add adapter for lucia-auth to use edgedb

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Want to contribute to the list? Follow the [contributing guide](/CONTRIBUTING.md
 - [EdgeDB FastAPI Users](https://github.com/0xsirsaif/fastapiusers-edgedb) - An adapter for FastAPI Users that utilizes EdgeDB as storage.
 - [EdgeDB Grafana Backend](https://github.com/washed/edgedb-grafana-backend) - A Grafana backend plugin allowing you to use EdgeDB as a data source.
 - [EdgeDB Grafana Frontend](https://github.com/edgedb/edgedb-grafana-frontend) - A Grafana frontend plugin allowing you to fetch data from EdgeDB's HTTP endpoint.
+- [EdgeDB Lucia-Auth Adapter](https://github.com/JitPackJoyride/lucia-adapter-edgedb) - An adapter for [Lucia-Auth](https://lucia-auth.com/) that utilizes EdgeDB as storage for your authentication and user data.
 
 ## Templates
 - [Create T3-EdgeDB App](https://github.com/PastelStoic/create-t3-edgedb-app) - The [T3 stack](https://init.tips/), but the database of choice is EdgeDB.


### PR DESCRIPTION
This is a library to use EdgeDB in a Node.js project with the authentication library Lucia-Auth. It should be very helpful for devs looking to use EdgeDB with an authentication library that supports OAuth and dealing with cookies or bearer tokens out of the box.