### PR TITLE
Add Internal Affairs (看無間道學EdgeDB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,8 @@ Want to contribute to the list? Follow the [contributing guide](/CONTRIBUTING.md
 - [EdgeDB 3.0 Launch](https://www.youtube.com/watch?v=bqD5CThzmw4)
 - [EdgeDB Office Hours](https://www.youtube.com/playlist?list=PLhNSoGM2ik6Rd3b5TT1DJzQej8jtcSYGe)
 - [End-to-end type safety](https://www.youtube.com/watch?v=NAbEo2_6Us4&t=2422s)
+
+## Other languages
+
+### Chinese
+- [看無間道學EdgeDB](https://jrycw.github.io/edgedb-ia/): A ten-part course inspired by [Easy EdgeDB](https://www.edgedb.com/easy-edgedb) that follows the story in the 2002 Hong Kong action thriller film Infernal Affairs. [Source code](https://github.com/jrycw/edgedb-ia)


### PR DESCRIPTION
I was thrilled to see this ten-part EdgeDB book [announced yesterday on LinkedIn](https://www.linkedin.com/posts/yichengwu_github-jrycwedgedb-ia-edgedb-learning-activity-7158029684826329088-XZPv?utm_source=share&utm_medium=member_desktop) and we might want to put it in the documentation somewhere as well, but as a user-created project I think adding here makes sense too.

Since non-English resources are always going to be much less common, I'm thinking they could just be put into their own section instead of needing to go under applications/videos/and all the rest of the main sections. What do you think?

@raddevon 